### PR TITLE
Allow "today" as input

### DIFF
--- a/DataProcessing/QuiverInsiderTradingDataDownloader.cs
+++ b/DataProcessing/QuiverInsiderTradingDataDownloader.cs
@@ -94,7 +94,7 @@ namespace QuantConnect.DataProcessing
             var today = DateTime.UtcNow.Date;
             try
             {
-                if (processDate >= today || processDate == DateTime.MinValue)
+                if (processDate > today || processDate == DateTime.MinValue)
                 {
                     Log.Trace($"Encountered data from invalid date: {processDate:yyyy-MM-dd} - Skipping");
                     return false;


### PR DESCRIPTION
Allow the date of data retreival as an input date for the data processor, since it was using end date as input.